### PR TITLE
Make sure announcing always promises

### DIFF
--- a/game.js
+++ b/game.js
@@ -213,7 +213,7 @@ function setupSpeechSynthesis() {
 
 function announce(text) {
     if (SystemState.speechSynthesisVoice === null) {
-        return;
+        return new Promise((resolve, reject) => {resolve()});
     }
 
     let utterance = new SpeechSynthesisUtterance();


### PR DESCRIPTION
We have to return an empty promise if the speech synthesis is not available.