### PR TITLE
Log platform and browser

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,3 +1,5 @@
+console.log("Navigator platform is", navigator.platform)
+
 const thiefMaxDistance = 5;
 
 /**


### PR DESCRIPTION
We log the user platform and the browser to help us debug issues on different computers. This is especially relevant for the gamepad numbers which we have to tweak for different settings.