### PR TITLE
Fix selecting levels in a ring

### DIFF
--- a/game.js
+++ b/game.js
@@ -466,7 +466,12 @@ Select the level:
      * @param {number } delta
      */
     changeSelection(delta) {
-        this.levelIndex = (this.levelIndex + delta) % levels.length;
+        if (this.levelIndex + delta < 0) {
+            this.levelIndex = levels.length + (this.levelIndex + delta);
+        } else {
+            this.levelIndex = (this.levelIndex + delta) % levels.length;
+        }
+
         this.announceLevel();
     }
 


### PR DESCRIPTION
JavaScript handles negative numbers in module operation differently to some other languages, so we have to substract instead of computing the modulo.