### PR TITLE
Skip logging speech interruptions

### DIFF
--- a/game.js
+++ b/game.js
@@ -1093,7 +1093,13 @@ function announce(text) {
 
     return new Promise((resolve, reject) => {
         utterance.onend = resolve;
-        utterance.onerror = reject
+        utterance.onerror = (errorEvent) => {
+            if (errorEvent.error === 'interrupted') {
+                resolve();
+            } else {
+                reject(errorEvent)
+            }
+        }
     })
 }
 


### PR DESCRIPTION
While other errors are interesting, interruptions are very common when a button is pressed during the speech.