### PR TITLE
Fix "to drink" icon

### DIFF
--- a/additional-emojis/to-drink.png
+++ b/additional-emojis/to-drink.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:077fc0b0d108813d03d37d20435e3a4d7f3097ef4c8cd1da025e541ff3118b10
-size 243295
+oid sha256:be045352c48f9774b3d8dab7ee6d3e7e9909608ecc6fbf26b8cf4aac6a93dd70
+size 13962


### PR DESCRIPTION
We mistakenly saved HTML instead of the PNG.